### PR TITLE
4-move-set-command-status-logic-to-backend

### DIFF
--- a/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
+++ b/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
@@ -8,10 +8,9 @@ import { fetchCommands } from "@/queries/fetchCommands.ts";
 import { fetchUserConfig } from "@/queries/fetchUserConfig.ts";
 import { useCommandStore } from "@/store/commandStore.ts";
 import { CommandStatus } from "@/types/CommandStatus.ts";
+import { updateCommandStatus } from "@/useCases/command/updateCommandStatus.ts";
 
 export const EventListenersContainer = () => {
-  const setCommandsStatus = useCommandStore((state) => state.setCommandsStatus);
-  const commandsStatus = useCommandStore((state) => state.commandsStatus);
   const commandsLogs = useCommandStore((state) => state.commandsLogs);
   const setCommandsLogs = useCommandStore((state) => state.setCommandsLogs);
 
@@ -36,7 +35,7 @@ export const EventListenersContainer = () => {
           newLogs[id] = [];
         }
         newLogs[id].push(line);
-        
+
         if (newLogs[id].length > 100) {
           newLogs[id] = newLogs[id].slice(-100); // Keep only the last 100 lines
         }
@@ -63,13 +62,14 @@ export const EventListenersContainer = () => {
 
     eventService.eventsOn(
       Event.PROCESS_FINISHED,
-      (data: EventData[Event.PROCESS_FINISHED]) => {
-        const newCommandsStatus = {
-          ...commandsStatus,
-          [data]: CommandStatus.IDLE,
-        };
-        setCommandsStatus(newCommandsStatus);
-      },
+      (data: EventData[Event.PROCESS_FINISHED]) =>
+        updateCommandStatus(data, CommandStatus.IDLE),
+    );
+
+    eventService.eventsOn(
+      Event.PROCESS_STARTED,
+      (data: EventData[Event.PROCESS_STARTED]) =>
+        updateCommandStatus(data, CommandStatus.RUNNING),
     );
 
     eventService.eventsOn(Event.GET_USER_CONFIG, () => {

--- a/cmd/gomander/frontend/src/contracts/types.ts
+++ b/cmd/gomander/frontend/src/contracts/types.ts
@@ -13,6 +13,7 @@ export enum Event {
   SUCCESS_NOTIFICATION = event.Event.SUCCESS_NOTIFICATION,
   ERROR_NOTIFICATION = event.Event.ERROR_NOTIFICATION,
   PROCESS_FINISHED = event.Event.PROCESS_FINISHED,
+  PROCESS_STARTED = event.Event.PROCESS_STARTED,
   GET_USER_CONFIG = event.Event.GET_USER_CONFIG,
   GET_COMMAND_GROUPS = event.Event.GET_COMMAND_GROUPS,
 }
@@ -25,6 +26,7 @@ export type EventData = {
   };
   [Event.ERROR_NOTIFICATION]: string;
   [Event.PROCESS_FINISHED]: string;
+  [Event.PROCESS_STARTED]: string;
   [Event.SUCCESS_NOTIFICATION]: string;
   [Event.GET_USER_CONFIG]: null;
   [Event.GET_COMMAND_GROUPS]: null;

--- a/cmd/gomander/frontend/src/useCases/command/cleanCommandLogs.ts
+++ b/cmd/gomander/frontend/src/useCases/command/cleanCommandLogs.ts
@@ -1,0 +1,10 @@
+import { commandStore } from "@/store/commandStore.ts";
+
+export const cleanCommandLogs = (commandId: string): void => {
+  const { commandsLogs, setCommandsLogs } = commandStore.getState();
+
+  setCommandsLogs({
+    ...commandsLogs,
+    [commandId]: [],
+  });
+};

--- a/cmd/gomander/frontend/src/useCases/command/startCommand.ts
+++ b/cmd/gomander/frontend/src/useCases/command/startCommand.ts
@@ -1,23 +1,8 @@
 import { dataService } from "@/contracts/service.ts";
-import { commandStore } from "@/store/commandStore.ts";
-import { CommandStatus } from "@/types/CommandStatus.ts";
+import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
 
 export const startCommand = async (commandId: string) => {
-  const { setCommandsStatus, commandsStatus, commandsLogs, setCommandsLogs } =
-    commandStore.getState();
-
-  const newCommandsStatus = {
-    ...commandsStatus,
-    [commandId]: CommandStatus.RUNNING,
-  };
-
-  const newCommandsLogs = {
-    ...commandsLogs,
-    [commandId]: [], // Initialize logs for the command being executed
-  };
-
-  setCommandsStatus(newCommandsStatus);
-  setCommandsLogs(newCommandsLogs);
+  cleanCommandLogs(commandId);
 
   await dataService.runCommand(commandId);
 };

--- a/cmd/gomander/frontend/src/useCases/command/updateCommandStatus.ts
+++ b/cmd/gomander/frontend/src/useCases/command/updateCommandStatus.ts
@@ -1,0 +1,13 @@
+import { commandStore } from "@/store/commandStore";
+import type { CommandStatus } from "@/types/CommandStatus.ts";
+
+export const updateCommandStatus = (id: string, status: CommandStatus) => {
+  const { commandsStatus, setCommandsStatus } = commandStore.getState();
+
+  const updatedStatus = {
+    ...commandsStatus,
+    [id]: status,
+  };
+
+  setCommandsStatus(updatedStatus);
+};

--- a/cmd/gomander/frontend/src/useCases/logging/clearCurrentLogs.ts
+++ b/cmd/gomander/frontend/src/useCases/logging/clearCurrentLogs.ts
@@ -1,15 +1,12 @@
 import { commandStore } from "@/store/commandStore.ts";
+import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
 
 export const clearCurrentLogs = () => {
-  const { activeCommandId, commandsLogs, setCommandsLogs } =
-    commandStore.getState();
+  const { activeCommandId } = commandStore.getState();
 
   if (!activeCommandId) {
     return;
   }
 
-  setCommandsLogs({
-    ...commandsLogs,
-    [activeCommandId]: [],
-  });
+  cleanCommandLogs(activeCommandId);
 };

--- a/cmd/gomander/frontend/wailsjs/go/models.ts
+++ b/cmd/gomander/frontend/wailsjs/go/models.ts
@@ -22,6 +22,7 @@ export namespace event {
 	export enum Event {
 	    GET_COMMANDS = "get_commands",
 	    PROCESS_FINISHED = "process_finished",
+	    PROCESS_STARTED = "process_started",
 	    NEW_LOG_ENTRY = "new_log_entry",
 	    ERROR_NOTIFICATION = "error_notification",
 	    SUCCESS_NOTIFICATION = "success_notification",

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -8,6 +8,7 @@ type Event string
 
 const (
 	GetCommands         Event = "get_commands"
+	ProcessStarted      Event = "process_started"
 	ProcessFinished     Event = "process_finished"
 	NewLogEntry         Event = "new_log_entry"
 	ErrorNotification   Event = "error_notification"
@@ -22,6 +23,7 @@ var Events = []struct {
 }{
 	{Value: GetCommands, TSName: strings.ToUpper(string(GetCommands))},
 	{Value: ProcessFinished, TSName: strings.ToUpper(string(ProcessFinished))},
+	{Value: ProcessStarted, TSName: strings.ToUpper(string(ProcessStarted))},
 	{Value: NewLogEntry, TSName: strings.ToUpper(string(NewLogEntry))},
 	{Value: ErrorNotification, TSName: strings.ToUpper(string(ErrorNotification))},
 	{Value: SuccessNotification, TSName: strings.ToUpper(string(SuccessNotification))},

--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -56,6 +56,8 @@ func (c *Runner) RunCommand(command Command, environmentPaths []string) error {
 		return err
 	}
 
+	c.eventEmitter.EmitEvent(event.ProcessStarted, command.Id)
+
 	// Save the project in the runningCommands map
 	c.runningCommands[command.Id] = cmd
 


### PR DESCRIPTION
Move logic to set the status to RUNNING to the backend, being the frontend a simple reaction. 

Extra: refactor to simplify use cases