### PR TITLE
fix: remove commands from runner map once stopped

### DIFF
--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -15,7 +15,6 @@ import (
 
 var ExpectedTerminationLogs = []string{
 	"signal: terminated",
-	"signal: terminated",
 	"signal: interrupt",
 	"signal: killed",
 	"exit status 143",
@@ -78,7 +77,7 @@ func (c *Runner) RunCommand(command Command, environmentPaths []string, baseWork
 	// Stream stderr
 	go c.streamOutput(command.Id, stderr)
 
-	// Wait in background until the command finishes
+	// Wait in background until the command finishes, because it ends naturally or because it is stopped.
 	go func() {
 		err := cmd.Wait()
 		// Notify the event emitter that the command has finished and remove it from the runningCommands map
@@ -107,13 +106,7 @@ func (c *Runner) StopRunningCommand(id string) error {
 		return errors.New("No running command with id: " + id)
 	}
 
-	err := platform.StopProcessGracefully(runningCommand)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return platform.StopProcessGracefully(runningCommand)
 }
 
 func (c *Runner) StopAllRunningCommands() []error {

--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -112,13 +112,11 @@ func (c *Runner) StopRunningCommand(id string) error {
 func (c *Runner) StopAllRunningCommands() []error {
 	errs := make([]error, 0)
 
-	for id, cmd := range c.runningCommands {
+	for _, cmd := range c.runningCommands {
 		err := platform.StopProcessGracefully(cmd)
 
 		if err != nil {
 			errs = append(errs, err)
-		} else {
-			c.eventEmitter.EmitEvent(event.ProcessFinished, id)
 		}
 	}
 

--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -112,7 +112,15 @@ func (c *Runner) StopRunningCommand(id string) error {
 func (c *Runner) StopAllRunningCommands() []error {
 	errs := make([]error, 0)
 
+	// Create a slice to hold commands to stop
+	// this is necessary because we should not modify the map while iterating over it
+	commandsToStop := make([]*exec.Cmd, 0, len(c.runningCommands))
+
 	for _, cmd := range c.runningCommands {
+		commandsToStop = append(commandsToStop, cmd)
+	}
+
+	for _, cmd := range commandsToStop {
 		err := platform.StopProcessGracefully(cmd)
 
 		if err != nil {

--- a/internal/project/runner.go
+++ b/internal/project/runner.go
@@ -3,13 +3,14 @@ package project
 import (
 	"bufio"
 	"errors"
+	"io"
+	"os"
+	"os/exec"
+
 	"gomander/internal/event"
 	"gomander/internal/helpers"
 	"gomander/internal/logger"
 	"gomander/internal/platform"
-	"io"
-	"os"
-	"os/exec"
 )
 
 type Runner struct {
@@ -87,7 +88,15 @@ func (c *Runner) StopRunningCommand(id string) error {
 		return errors.New("No running runningCommand for project: " + id)
 	}
 
-	return platform.StopProcessGracefully(runningCommand)
+	err := platform.StopProcessGracefully(runningCommand)
+
+	if err != nil {
+		return err
+	}
+
+	delete(c.runningCommands, id)
+
+	return nil
 }
 
 func (c *Runner) StopAllRunningCommands() []error {


### PR DESCRIPTION
# Postmortem

When we were stopping a single command, we were not removing that entry from the runner "running processes" map, so when the cleanup function tried to stop it, that command was no longer running.