### PR TITLE
feat: add ExportableProject to omit base working directory when exporting

### DIFF
--- a/cmd/gomander/frontend/src/components/modals/Project/ImportProjectModal.tsx
+++ b/cmd/gomander/frontend/src/components/modals/Project/ImportProjectModal.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog.tsx";
 import { Form } from "@/components/ui/form.tsx";
-import type { Project } from "@/contracts/types.ts";
+import type { ExportableProject } from "@/contracts/types.ts";
 import { importProject } from "@/useCases/project/importProject.ts";
 
 export const ImportProjectModal = ({
@@ -28,13 +28,13 @@ export const ImportProjectModal = ({
   open: boolean;
   onSuccess: () => Promise<void>;
   onClose: () => void;
-  project: Project | null;
+  project: ExportableProject | null;
 }) => {
   const form = useForm<FormSchemaType>({
     resolver: zodResolver(formSchema),
     values: {
       name: project?.name || "",
-      baseWorkingDirectory: project?.baseWorkingDirectory || "",
+      baseWorkingDirectory: "",
     },
   });
 
@@ -50,11 +50,13 @@ export const ImportProjectModal = ({
       return;
     }
 
-    await importProject({
-      ...project,
-      name: values.name,
-      baseWorkingDirectory: values.baseWorkingDirectory,
-    });
+    await importProject(
+      {
+        ...project,
+        name: values.name,
+      },
+      values.baseWorkingDirectory,
+    );
 
     await onSuccess();
     handleOpenChange(false);

--- a/cmd/gomander/frontend/src/contracts/types.ts
+++ b/cmd/gomander/frontend/src/contracts/types.ts
@@ -6,6 +6,7 @@ export type Command = project.Command;
 export type UserConfig = config.UserConfig;
 export type CommandGroup = project.CommandGroup;
 export type Project = project.Project;
+export type ExportableProject = project.ExportableProject;
 
 // Enums
 export enum Event {

--- a/cmd/gomander/frontend/src/screens/ProjectSelectionScreen/ProjectSelectionScreen.tsx
+++ b/cmd/gomander/frontend/src/screens/ProjectSelectionScreen/ProjectSelectionScreen.tsx
@@ -7,7 +7,7 @@ import { DeleteProjectModal } from "@/components/modals/Project/DeleteProjectMod
 import { ImportProjectModal } from "@/components/modals/Project/ImportProjectModal.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { dataService } from "@/contracts/service.ts";
-import type { Project } from "@/contracts/types.ts";
+import type { ExportableProject } from "@/contracts/types.ts";
 import { ProjectCard } from "@/screens/ProjectSelectionScreen/components/ProjectCard.tsx";
 import { useGetAvailableProjects } from "@/screens/ProjectSelectionScreen/hooks/useGetAvailableProjects.ts";
 import { deleteProject } from "@/useCases/project/deleteProject.ts";
@@ -17,7 +17,7 @@ export const ProjectSelectionScreen = () => {
     string | null
   >(null);
   const [projectBeingImported, setProjectBeingImported] =
-    useState<Project | null>(null);
+    useState<ExportableProject | null>(null);
 
   const [createProjectModalOpen, setCreateProjectModalOpen] = useState(false);
 

--- a/cmd/gomander/frontend/src/useCases/project/importProject.ts
+++ b/cmd/gomander/frontend/src/useCases/project/importProject.ts
@@ -1,6 +1,9 @@
 import { dataService } from "@/contracts/service.ts";
-import type { Project } from "@/contracts/types.ts";
+import type { ExportableProject } from "@/contracts/types.ts";
 
-export const importProject = async (project: Project) => {
-  await dataService.importProject(project);
+export const importProject = async (
+  project: ExportableProject,
+  newBaseWorkingDir: string,
+) => {
+  await dataService.importProject(project, newBaseWorkingDir);
 };

--- a/cmd/gomander/frontend/wailsjs/go/app/App.d.ts
+++ b/cmd/gomander/frontend/wailsjs/go/app/App.d.ts
@@ -23,11 +23,11 @@ export function GetCommands():Promise<Record<string, project.Command>>;
 
 export function GetCurrentProject():Promise<project.Project>;
 
-export function GetProjectToImport():Promise<project.Project>;
+export function GetProjectToImport():Promise<project.ExportableProject>;
 
 export function GetUserConfig():Promise<config.UserConfig>;
 
-export function ImportProject(arg1:project.Project):Promise<void>;
+export function ImportProject(arg1:project.ExportableProject,arg2:string):Promise<void>;
 
 export function OpenProject(arg1:string):Promise<project.Project>;
 

--- a/cmd/gomander/frontend/wailsjs/go/app/App.js
+++ b/cmd/gomander/frontend/wailsjs/go/app/App.js
@@ -50,8 +50,8 @@ export function GetUserConfig() {
   return window['go']['app']['App']['GetUserConfig']();
 }
 
-export function ImportProject(arg1) {
-  return window['go']['app']['App']['ImportProject'](arg1);
+export function ImportProject(arg1, arg2) {
+  return window['go']['app']['App']['ImportProject'](arg1, arg2);
 }
 
 export function OpenProject(arg1) {

--- a/cmd/gomander/frontend/wailsjs/go/models.ts
+++ b/cmd/gomander/frontend/wailsjs/go/models.ts
@@ -35,6 +35,12 @@ export namespace project {
 	    name: string;
 	    commands: string[];
 	}
+	export interface ExportableProject {
+	    id: string;
+	    name: string;
+	    commands: Record<string, Command>;
+	    commandGroups: CommandGroup[];
+	}
 	export interface Project {
 	    id: string;
 	    name: string;

--- a/internal/app/projecthandlers.go
+++ b/internal/app/projecthandlers.go
@@ -112,8 +112,8 @@ func (a *App) ExportProject(projectConfigId string) error {
 	return nil
 }
 
-func (a *App) ImportProject(p project.Project) error {
-	err := project.ImportProject(p)
+func (a *App) ImportProject(ep project.ExportableProject, baseWorkingDir string) error {
+	err := project.ImportProject(ep, baseWorkingDir)
 	if err != nil {
 		a.eventEmitter.EmitEvent(event.ErrorNotification, "Failed to import project: "+err.Error())
 		return err
@@ -123,7 +123,7 @@ func (a *App) ImportProject(p project.Project) error {
 	return nil
 }
 
-func (a *App) GetProjectToImport() (*project.Project, error) {
+func (a *App) GetProjectToImport() (*project.ExportableProject, error) {
 	filePath, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{Title: "Select a project file", Filters: []runtime.FileFilter{{DisplayName: "JSON Files", Pattern: "*.json"}}})
 	if err != nil {
 		return nil, err
@@ -132,5 +132,5 @@ func (a *App) GetProjectToImport() (*project.Project, error) {
 		return nil, errors.New("import cancelled")
 	}
 
-	return project.LoadProjectFromPath(filePath)
+	return project.LoadExportedProjectFromPath(filePath)
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -7,3 +7,29 @@ type Project struct {
 	Commands             map[string]Command `json:"commands"`
 	CommandGroups        []CommandGroup     `json:"commandGroups"`
 }
+
+type ExportableProject struct {
+	Id            string             `json:"id"`
+	Name          string             `json:"name"`
+	Commands      map[string]Command `json:"commands"`
+	CommandGroups []CommandGroup     `json:"commandGroups"`
+}
+
+func (p *Project) ToExportable() *ExportableProject {
+	return &ExportableProject{
+		Id:            p.Id,
+		Name:          p.Name,
+		Commands:      p.Commands,
+		CommandGroups: p.CommandGroups,
+	}
+}
+
+func (e *ExportableProject) ToProject(baseWorkingDirectory string) *Project {
+	return &Project{
+		Id:                   e.Id,
+		Name:                 e.Name,
+		BaseWorkingDirectory: baseWorkingDirectory,
+		Commands:             e.Commands,
+		CommandGroups:        e.CommandGroups,
+	}
+}


### PR DESCRIPTION
Approach un poco menos `YAGNI` para omitir el `baseWorkingDirectory` al exportar.

Considerar esta PR una PoC para debatir si nos gusta esta forma de hacerlo.